### PR TITLE
On-prem compatibility and paginated results list append fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -127,3 +127,5 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ Python script to set Recovery Lock key for Apple M1 computers.
 
 The recovery key will now be showen under *Jamf Pro > Computer > Inventory > Security > Recovery Lock Password* (Show Password)
 
-👉 Note that the Recovery Lock status will be showen as *Not Eanbled* until the next inventory collection.
+👉 Note that the Recovery Lock status will be shown as *Not Enabled* until the next inventory collection.

--- a/auth/bearer_auth.py
+++ b/auth/bearer_auth.py
@@ -18,7 +18,7 @@ def request_token():
     } 
 
     try:
-        response = requests.request("POST", f'https://{instance_id}.jamfcloud.com/api/v1/auth/token', headers=headers)
+        response = requests.request("POST", f'https://{instance_id}/api/v1/auth/token', headers=headers)
         response.raise_for_status()
 
     except requests.exceptions.HTTPError as err:

--- a/auth/creds.py
+++ b/auth/creds.py
@@ -1,3 +1,3 @@
-instance_id = '' # usually is the company name (e.g. 'companyxyz' for https://companyxyz.jamfcloud.com)
+instance_id = '' # Jamf Pro URL (e.g. Jamf Cloud == https://companyxyz.jamfcloud.com, On-Prem Jamf Pro == jamfpro.companyname.com:8443
 username = ''    # API user that can be generated in Jamf Pro -> System Settings -> Jamf Pro User Accounts & Groups
 password = ''    # password for the above user

--- a/computers.py
+++ b/computers.py
@@ -17,7 +17,7 @@ def get_computer_count():
 
     try:
         response = requests.get(
-            url=f'https://{instance_id}.jamfcloud.com/api/v1/computers-inventory?section=HARDWARE&page=0&page-size=1&sort=id%3Aasc',
+            url=f'https://{instance_id}/api/v1/computers-inventory?section=HARDWARE&page=0&page-size=1&sort=id%3Aasc',
             headers=headers
         )
         response.raise_for_status()
@@ -47,7 +47,7 @@ def get_arm64(filter = None):
 
         try:
             response = requests.get(
-                url=f'https://{instance_id}.jamfcloud.com/api/v1/computers-inventory?section=HARDWARE&page={pageIndex}&page-size={computers_per_page}&sort=id%3Aasc&{filter}',
+                url=f'https://{instance_id}/api/v1/computers-inventory?section=HARDWARE&page={pageIndex}&page-size={computers_per_page}&sort=id%3Aasc&{filter}',
                 headers=headers
             )
             response.raise_for_status()
@@ -62,6 +62,7 @@ def get_arm64(filter = None):
                 computers_id.append(computer['id'])
 
     return computers_id
+    
 
 
 def get_mgmt_id(computers_id):
@@ -71,19 +72,18 @@ def get_mgmt_id(computers_id):
     Parameters:
         computers_id - (e.g. ['10', '12']]). List of Jamf computers id 
     """
+    computers_mgmt_id = []
 
     for pageIndex in range(number_of_pages):
         try:
             response = requests.get(
-                url = f'https://{instance_id}.jamfcloud.com/api/preview/computers?page={pageIndex}&page-size={computers_per_page}&sort=name%3Aasc',
+                url = f'https://{instance_id}/api/preview/computers?page={pageIndex}&page-size={computers_per_page}&sort=name%3Aasc',
                 headers=headers
             )
             response.raise_for_status()
             
         except requests.exceptions.HTTPError as err:
             raise SystemExit(err)
-
-        computers_mgmt_id = []
 
         computers = response.json()['results']
 

--- a/recovery_lock.py
+++ b/recovery_lock.py
@@ -28,7 +28,7 @@ def set_key(computer_name, management_id, recovery_lock_key):
     }
 
     try:
-        response = requests.request("POST", f'https://{instance_id}.jamfcloud.com/api/preview/mdm/commands', headers=headers, json=payload)
+        response = requests.request("POST", f'https://{instance_id}/api/preview/mdm/commands', headers=headers, json=payload)
 
         response.raise_for_status()
         


### PR DESCRIPTION
Thank you for this script! It will help greatly in enabling recovery lock for our already deployed devices. Changes in this PR listed below:

1. Add .DS_Store to the .gitignore

2. Fixed a couple typos in the README

3. Modified all API URL's from `https://{instance_id}.jamfcloud.com/` to `https://{instance_id}/` to allow for on-prem Jamf Pro compatibility.

4.  Modified the 'instance_id' comment in auth/creds.py to explain the need for a full URL because of change #3

5. In computers.py, I moved the `computers_mgmt_id = []` list to the top of the `get_mgmt_id` function and outside any loops. In an environment with multiple pages of results, this was causing the computers_mgmt_id list to be overwritten by each subsequent page's results. As an example, we have roughly 3500 devices in our environment, when I would filter the results to a single device for testing and print the results of `computers_mgmt_id` it would look like this:

```
[]
[{'id': 'someID', 'name': 'someDeviceName', 'mgmt_id': 'someMgmtID'}]
[]
[]
```

This is with 3500 devices, 1000 results per page and the device I'm filtering for existing on the second page. Each subsequent result would overwrite the last and with `[]` being the last, nothing would be sent to `main.py`.

Thanks, again!